### PR TITLE
Custom templates with toast-component

### DIFF
--- a/documentation/angular/src/app/examples/c-toasts/c-toasts.component.html
+++ b/documentation/angular/src/app/examples/c-toasts/c-toasts.component.html
@@ -4,21 +4,37 @@
       <c-card-content>
         <h5>Per toast options</h5>
 
-        <c-text-field [(ngModel)]="message" label="Message" hide-details cControl></c-text-field>
+        <c-switch [value]="custom" (changeValue)="custom = !custom">
+          Bypass default content
+        </c-switch>
 
-        <c-text-field
-          [(ngModel)]="title"
-          label="Title (optional)"
-          hide-details
-          cControl
-        ></c-text-field>
+        <ng-container *ngIf="!custom; else customContentTemplate">
+          <c-text-field [(ngModel)]="message" label="Message" hide-details cControl></c-text-field>
 
-        <c-text-field
-          [(ngModel)]="closeText"
-          label="Close text (optional)"
-          hide-details
-          cControl
-        ></c-text-field>
+          <c-text-field
+            [(ngModel)]="title"
+            label="Title (optional)"
+            hide-details
+            cControl
+          ></c-text-field>
+
+          <c-text-field
+            [(ngModel)]="closeText"
+            label="Close text (optional)"
+            hide-details
+            cControl
+          ></c-text-field>
+        </ng-container>
+
+        <ng-template #customContentTemplate>
+          <c-text-field
+            [(ngModel)]="customContent"
+            label="Custom content"
+            rows="10"
+            hint="Text or HTML"
+            cControl
+          ></c-text-field>
+        </ng-template>
 
         <c-text-field
           [(ngModel)]="duration"
@@ -45,7 +61,13 @@
           Show progress (optional)
         </c-checkbox>
 
-        <c-button fit [disabled]="!message" (click)="onAddToast()">Add toast</c-button>
+        <c-button
+          fit
+          [disabled]="(!custom && !message) || (custom && !customContent)"
+          (click)="onAddToast()"
+        >
+          Add toast
+        </c-button>
       </c-card-content>
     </c-card>
 

--- a/documentation/angular/src/app/examples/c-toasts/c-toasts.component.ts
+++ b/documentation/angular/src/app/examples/c-toasts/c-toasts.component.ts
@@ -13,11 +13,15 @@ import {
 })
 export class CToastsComponent {
   // @example-start|basic
+  custom = false;
+
   title = '';
 
   message = 'A toast message';
 
   closeText = '';
+
+  customContent: string;
 
   type = 'info';
 
@@ -62,6 +66,7 @@ export class CToastsComponent {
       persistent: this.persistent,
       progress: this.progress,
       closeText: this.closeText,
+      customContent: this.customContent
     };
 
     const toasts = document.querySelector('#toasts') as HTMLCToastsElement;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "csc-ui",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "csc-ui",
-      "version": "0.4.23",
+      "version": "0.4.24",
       "license": "MIT",
       "dependencies": {
         "@mdi/js": "^6.7.96",

--- a/src/components/c-toast/c-toast.scss
+++ b/src/components/c-toast/c-toast.scss
@@ -55,6 +55,9 @@
   grid-auto-columns: auto;
   grid-auto-flow: column;
   grid-template-columns: 24px 1fr;
+}
+
+.c-toast__item, .c-toast__custom-item {
   font-weight: 300;
 }
 

--- a/src/components/c-toast/c-toast.tsx
+++ b/src/components/c-toast/c-toast.tsx
@@ -146,19 +146,27 @@ export class CToast {
       >
         <span class="visuallyhidden">{this.message.type} notification</span>
 
-        <div class="c-toast__item">
-          <svg viewBox="0 0 24 24">
-            <path d={this._icons[this.message.type]}></path>
-          </svg>
-
-          <div class="c-toast__content">
-            {!!this.message.title && <p>{this.message.title}</p>}
-
-            {this.message.message}
+        {this.message.customContent ? (
+          <div class="c-toast__custom-item">
+            <div class="c-toast__content">
+              <div innerHTML={this.message.customContent}></div>
+            </div>
           </div>
+        ) : (
+          <div class="c-toast__item">
+            <svg viewBox="0 0 24 24">
+              <path d={this._icons[this.message.type]}></path>
+            </svg>
 
-          {!this.message.indeterminate && this._renderCloseButton()}
-        </div>
+            <div class="c-toast__content">
+              {!!this.message.title && <p>{this.message.title}</p>}
+
+              {this.message.message}
+            </div>
+
+            {!this.message.indeterminate && this._renderCloseButton()}
+          </div>
+        )}
 
         {showProgressBar && (
           <div

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -106,6 +106,7 @@ export interface CToastMessage {
   closeText?: string;
   indeterminate?: boolean;
   progress?: boolean;
+  customContent?: string;
 }
 
 export enum CAlertType {


### PR DESCRIPTION
Initial idea was to use `<slot>` tag when rendering dynamic child elements. 
This approach had some issues when rendering multiple toast-messages (in a stack) and it would render the slot content only within the "oldest" toast-notification.

Proposed solution takes content in string format and renders it in a `innerHTML` attribute of container div.

There shouldn't be safety concerns regarding use of `innerHTML` since user isn't interacting with manipulating the content of the component.