### PR TITLE
Custom toast content and documentation

### DIFF
--- a/documentation/angular/src/app/app.module.ts
+++ b/documentation/angular/src/app/app.module.ts
@@ -53,6 +53,7 @@ import { CToastsComponent } from './examples/c-toasts/c-toasts.component';
 import { ViewerMethodsComponent } from './viewer/viewer-methods/viewer-methods.component';
 import { CAlertComponent } from './examples/c-alert/c-alert.component';
 import { TypesComponent } from './types/types.component';
+import { SafeHtmlPipe } from './pipes/safe-html.pipe';
 
 @NgModule({
   declarations: [
@@ -103,6 +104,7 @@ import { TypesComponent } from './types/types.component';
     ViewerMethodsComponent,
     CAlertComponent,
     TypesComponent,
+    SafeHtmlPipe,
   ],
   imports: [
     BrowserModule,

--- a/documentation/angular/src/app/examples/c-toasts/c-toasts.component.html
+++ b/documentation/angular/src/app/examples/c-toasts/c-toasts.component.html
@@ -4,21 +4,39 @@
       <c-card-content>
         <h5>Per toast options</h5>
 
-        <c-text-field [(ngModel)]="message" label="Message" hide-details cControl></c-text-field>
+        <c-switch [value]="custom" (changeValue)="custom = !custom">
+          Bypass default content
+        </c-switch>
 
-        <c-text-field
-          [(ngModel)]="title"
-          label="Title (optional)"
-          hide-details
-          cControl
-        ></c-text-field>
+        <ng-container *ngIf="!custom; else customContentTemplate">
+          <c-text-field [(ngModel)]="message" label="Message" hide-details cControl></c-text-field>
 
-        <c-text-field
-          [(ngModel)]="closeText"
-          label="Close text (optional)"
-          hide-details
-          cControl
-        ></c-text-field>
+          <c-text-field
+            [(ngModel)]="title"
+            label="Title (optional)"
+            hide-details
+            cControl
+          ></c-text-field>
+
+          <c-text-field
+            [(ngModel)]="closeText"
+            label="Close text (optional)"
+            hide-details
+            cControl
+          ></c-text-field>
+        </ng-container>
+
+        <ng-template #customContentTemplate>
+          <span>Toasts with custom content are restricted to one (1) visible toast.</span>
+
+          <c-text-field
+            [(ngModel)]="customContent"
+            label="Custom content"
+            rows="10"
+            hint="Text or HTML"
+            cControl
+          ></c-text-field>
+        </ng-template>
 
         <c-text-field
           [(ngModel)]="duration"
@@ -45,7 +63,13 @@
           Show progress (optional)
         </c-checkbox>
 
-        <c-button fit [disabled]="!message" (click)="onAddToast()">Add toast</c-button>
+        <c-button
+          fit
+          [disabled]="(!custom && !message) || (custom && !customContent)"
+          (click)="onAddToast()"
+        >
+          Add toast
+        </c-button>
       </c-card-content>
     </c-card>
 
@@ -96,7 +120,9 @@
           [absolute]="absolute"
           [vertical]="vertical"
           [horizontal]="horizontal"
-        ></c-toasts>
+        >
+          <div *ngIf="customContent" [innerHTML]="customContent | safeHtml"></div>
+        </c-toasts>
       </div>
     </div>
   </c-row>

--- a/documentation/angular/src/app/examples/c-toasts/c-toasts.component.ts
+++ b/documentation/angular/src/app/examples/c-toasts/c-toasts.component.ts
@@ -13,11 +13,15 @@ import {
 })
 export class CToastsComponent {
   // @example-start|basic
+  custom = false;
+
   title = '';
 
   message = 'A toast message';
 
   closeText = '';
+
+  customContent: string;
 
   type = 'info';
 
@@ -62,6 +66,7 @@ export class CToastsComponent {
       persistent: this.persistent,
       progress: this.progress,
       closeText: this.closeText,
+      custom: this.custom,
     };
 
     const toasts = document.querySelector('#toasts') as HTMLCToastsElement;

--- a/documentation/angular/src/app/pipes/safe-html.pipe.ts
+++ b/documentation/angular/src/app/pipes/safe-html.pipe.ts
@@ -1,0 +1,12 @@
+import { Component, Pipe, PipeTransform } from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
+
+@Pipe({
+  name: 'safeHtml'
+})
+export class SafeHtmlPipe implements PipeTransform {
+  constructor(private sanitized: DomSanitizer) { }
+  transform(value) {
+    return this.sanitized.bypassSecurityTrustHtml(value);
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "csc-ui",
-  "version": "0.4.23",
+  "version": "0.4.27",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "csc-ui",
-      "version": "0.4.23",
+      "version": "0.4.27",
       "license": "MIT",
       "dependencies": {
         "@mdi/js": "^6.7.96",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "csc-ui",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "description": "CSC UI components",
   "main": "dist/index.cjs.js",
   "module": "dist/custom-elements/index.js",

--- a/src/components/c-toast/c-toast.tsx
+++ b/src/components/c-toast/c-toast.tsx
@@ -146,19 +146,27 @@ export class CToast {
       >
         <span class="visuallyhidden">{this.message.type} notification</span>
 
-        <div class="c-toast__item">
-          <svg viewBox="0 0 24 24">
-            <path d={this._icons[this.message.type]}></path>
-          </svg>
-
-          <div class="c-toast__content">
-            {!!this.message.title && <p>{this.message.title}</p>}
-
-            {this.message.message}
+        {this.message.custom ? (
+          <div class="c-toast__custom-item">
+            <div class="c-toast__content">
+              <slot></slot>
+            </div>
           </div>
+        ) : (
+          <div class="c-toast__item">
+            <svg viewBox="0 0 24 24">
+              <path d={this._icons[this.message.type]}></path>
+            </svg>
 
-          {!this.message.indeterminate && this._renderCloseButton()}
-        </div>
+            <div class="c-toast__content">
+              {!!this.message.title && <p>{this.message.title}</p>}
+
+              {this.message.message}
+            </div>
+
+            {!this.message.indeterminate && this._renderCloseButton()}
+          </div>
+        )}
 
         {showProgressBar && (
           <div

--- a/src/components/c-toasts/c-toasts.tsx
+++ b/src/components/c-toasts/c-toasts.tsx
@@ -53,21 +53,29 @@ export class CToasts {
    */
   @Method()
   async addToast(message: CToastMessage) {
-    requestAnimationFrame(() => {
-      const defaultOptions = this._getDefaultOptions();
+    const customMessages = this.messages.filter((message) => message.custom);
 
-      this.messages = [
-        ...this.messages,
-        {
-          ...defaultOptions,
-          ...message,
-          duration:
-            +message?.duration > 0
-              ? +message.duration
-              : defaultOptions.duration,
-        },
-      ];
-    });
+    if (message.custom && customMessages.length > 0) {
+      console.warn(
+        `Custom toast messages are restricted to 1 visible message due to slot reflection limitations.`,
+      );
+    } else {
+      requestAnimationFrame(() => {
+        const defaultOptions = this._getDefaultOptions();
+
+        this.messages = [
+          ...this.messages,
+          {
+            ...defaultOptions,
+            ...message,
+            duration:
+              +message?.duration > 0
+                ? +message.duration
+                : defaultOptions.duration,
+          },
+        ];
+      });
+    }
   }
 
   /**
@@ -102,10 +110,9 @@ export class CToasts {
 
   private _renderMessage(message: CToastMessage) {
     return (
-      <c-toast
-        message={message}
-        onClose={(e) => this._onMessageClose(e)}
-      ></c-toast>
+      <c-toast message={message} onClose={(e) => this._onMessageClose(e)}>
+        {message.custom && <slot />}
+      </c-toast>
     );
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -106,6 +106,7 @@ export interface CToastMessage {
   closeText?: string;
   indeterminate?: boolean;
   progress?: boolean;
+  custom?: boolean;
 }
 
 export enum CAlertType {


### PR DESCRIPTION
Implementation uses `<slot />` functionality when rendering dynamic child elements. 

This approach has issues when rendering multiple custom toast-messages. Therefore custom toast messages are restricted to one (1) custom toast. 

HTML sanitation in Angular documentation for toast components custom content shouldn't be safety concern but can be audited if necessary.