### PR TITLE
Optional adjacent details positioning & details label for progress bar

### DIFF
--- a/documentation/angular/src/app/examples/c-progress-bar/c-progress-bar.component.html
+++ b/documentation/angular/src/app/examples/c-progress-bar/c-progress-bar.component.html
@@ -16,3 +16,8 @@
   <c-progress-bar indeterminate></c-progress-bar>
   <c-progress-bar indeterminate color="#16c1dd"></c-progress-bar>
 </app-example>
+
+<app-example title="Adjacent details" name="adjacent" component="c-progress-bar" rows>
+  <c-progress-bar single-line value="25"></c-progress-bar>
+  <c-progress-bar single-line label="complete" value="55"></c-progress-bar>
+</app-example>

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -669,6 +669,14 @@ export namespace Components {
          */
         "indeterminate": boolean;
         /**
+          * Optional details message next to percentage display
+         */
+        "label": string;
+        /**
+          * Place details next to progress bar
+         */
+        "singleLine": boolean;
+        /**
           * Progress bar value in percentage (0 to 100)
          */
         "value": number;
@@ -2297,6 +2305,14 @@ declare namespace LocalJSX {
           * Indeterminate state of the progress bar
          */
         "indeterminate"?: boolean;
+        /**
+          * Optional details message next to percentage display
+         */
+        "label"?: string;
+        /**
+          * Place details next to progress bar
+         */
+        "singleLine"?: boolean;
         /**
           * Progress bar value in percentage (0 to 100)
          */

--- a/src/components/c-progress-bar/c-progress-bar.scss
+++ b/src/components/c-progress-bar/c-progress-bar.scss
@@ -25,13 +25,24 @@
   transform: translateZ(0); // Safari - overflow: hidden & border-radius fix
   width: calc(100% - calc(var(--border-size) * 2));
 
+  &.adjacent-details {
+    flex: 1
+  }
+
   &__percentage {
     flex-basis: 100%;
     font-size: 14px;
     margin-top: 2px;
     text-align: end;
     white-space: nowrap;
+    padding-left: 16px;
+
+    &.adjacent-details {
+      flex: 0;
+    }
   }
+
+
 
   progress {
     background-color: var(--bar-color);

--- a/src/components/c-progress-bar/c-progress-bar.tsx
+++ b/src/components/c-progress-bar/c-progress-bar.tsx
@@ -20,6 +20,16 @@ export class CProgressBar {
   @Prop() hideDetails = false;
 
   /**
+   * Place details next to progress bar
+   */
+  @Prop() singleLine = false;
+
+  /**
+   * Optional details message next to percentage display
+   */
+  @Prop() label = '';
+
+  /**
    * Color of the bar (valid css color)
    *
    * @default var(--csc-primary)
@@ -50,6 +60,12 @@ export class CProgressBar {
     const classes = {
       'c-progress': true,
       'c-progress--indeterminate': this.indeterminate,
+      'adjacent-details': this.singleLine,
+    };
+
+    const detailsClasses = {
+      'c-progress__percentage': true,
+      'adjacent-details': this.singleLine,
     };
 
     const a11y = {
@@ -79,7 +95,9 @@ export class CProgressBar {
         </label>
 
         {!this.indeterminate && !this.hideDetails && (
-          <div class="c-progress__percentage">{value} %</div>
+          <div class={detailsClasses}>
+            {value} % {this.label}
+          </div>
         )}
       </Host>
     );

--- a/src/components/c-progress-bar/readme.md
+++ b/src/components/c-progress-bar/readme.md
@@ -7,12 +7,14 @@
 
 ## Properties
 
-| Property        | Attribute       | Description                                 | Type      | Default     |
-| --------------- | --------------- | ------------------------------------------- | --------- | ----------- |
-| `color`         | `color`         | Color of the bar (valid css color)          | `string`  | `undefined` |
-| `hideDetails`   | `hide-details`  | Hide the percentage display                 | `boolean` | `false`     |
-| `indeterminate` | `indeterminate` | Indeterminate state of the progress bar     | `boolean` | `false`     |
-| `value`         | `value`         | Progress bar value in percentage (0 to 100) | `number`  | `0`         |
+| Property        | Attribute       | Description                                         | Type      | Default     |
+| --------------- | --------------- | --------------------------------------------------- | --------- | ----------- |
+| `color`         | `color`         | Color of the bar (valid css color)                  | `string`  | `undefined` |
+| `hideDetails`   | `hide-details`  | Hide the percentage display                         | `boolean` | `false`     |
+| `indeterminate` | `indeterminate` | Indeterminate state of the progress bar             | `boolean` | `false`     |
+| `label`         | `label`         | Optional details message next to percentage display | `string`  | `''`        |
+| `singleLine`    | `single-line`   | Place details next to progress bar                  | `boolean` | `false`     |
+| `value`         | `value`         | Progress bar value in percentage (0 to 100)         | `number`  | `0`         |
 
 
 ----------------------------------------------


### PR DESCRIPTION
This PR suggests allowing user to position progress bar details on same row as progress bar.
Details can be appended with custom details message.

![image](https://user-images.githubusercontent.com/48789543/183357572-ed65dc5d-c3f1-46cf-ad50-57752fc631e1.png)
