### PR TITLE
Handle custom toast with slot functionality

### DIFF
--- a/documentation/angular/src/app/examples/c-toasts/c-toasts.component.html
+++ b/documentation/angular/src/app/examples/c-toasts/c-toasts.component.html
@@ -4,37 +4,21 @@
       <c-card-content>
         <h5>Per toast options</h5>
 
-        <c-switch [value]="custom" (changeValue)="custom = !custom">
-          Bypass default content
-        </c-switch>
+        <c-text-field [(ngModel)]="message" label="Message" hide-details cControl></c-text-field>
 
-        <ng-container *ngIf="!custom; else customContentTemplate">
-          <c-text-field [(ngModel)]="message" label="Message" hide-details cControl></c-text-field>
+        <c-text-field
+          [(ngModel)]="title"
+          label="Title (optional)"
+          hide-details
+          cControl
+        ></c-text-field>
 
-          <c-text-field
-            [(ngModel)]="title"
-            label="Title (optional)"
-            hide-details
-            cControl
-          ></c-text-field>
-
-          <c-text-field
-            [(ngModel)]="closeText"
-            label="Close text (optional)"
-            hide-details
-            cControl
-          ></c-text-field>
-        </ng-container>
-
-        <ng-template #customContentTemplate>
-          <c-text-field
-            [(ngModel)]="customContent"
-            label="Custom content"
-            rows="10"
-            hint="Text or HTML"
-            cControl
-          ></c-text-field>
-        </ng-template>
+        <c-text-field
+          [(ngModel)]="closeText"
+          label="Close text (optional)"
+          hide-details
+          cControl
+        ></c-text-field>
 
         <c-text-field
           [(ngModel)]="duration"
@@ -136,4 +120,20 @@
   </c-row>
 
   <c-toasts id="indeterminateToasts"></c-toasts>
+</app-example>
+
+<app-example
+  title="Custom template"
+  subtitle="Custom toasts are limited to one (1) visible toast"
+  name="custom"
+  component="c-toasts"
+>
+  <c-row gap="8">
+    <c-button [disabled]="hasCustomToast" (click)="onAddCustomToast()">Add toast</c-button>
+  </c-row>
+
+  <c-toasts id="customToast">
+    <p>This is a custom toast template.</p>
+    <c-button (click)="onRemoveCustomToast()">Remove toast</c-button>
+  </c-toasts>
 </app-example>

--- a/documentation/angular/src/app/examples/c-toasts/c-toasts.component.ts
+++ b/documentation/angular/src/app/examples/c-toasts/c-toasts.component.ts
@@ -1,6 +1,5 @@
 import { Component } from '@angular/core';
 import {
-  CRadioGroupItem,
   CSelectItem,
   CToastMessage,
   CToastType,
@@ -66,8 +65,6 @@ export class CToastsComponent {
       persistent: this.persistent,
       progress: this.progress,
       closeText: this.closeText,
-      custom: this.custom,
-      template: this.customContent,
     };
 
     const toasts = document.querySelector('#toasts') as HTMLCToastsElement;
@@ -96,6 +93,30 @@ export class CToastsComponent {
     const toasts = document.querySelector('#indeterminateToasts') as HTMLCToastsElement;
     toasts?.removeToast('indeterminate');
     this.hasToast = false;
+  }
+  // @example-end
+
+  // @example-start|custom
+  hasCustomToast = false
+
+  onAddCustomToast() {
+    const message: CToastMessage = {
+      message: '', // Required property
+      type: this.type as CToastType,
+      id: 'custom',
+      persistent: true,
+      custom: true,
+    };
+
+    const toast = document.querySelector('#customToast') as HTMLCToastsElement;
+    toast?.addToast(message);
+    this.hasCustomToast = true;
+  }
+
+  onRemoveCustomToast() {
+    const toast = document.querySelector('#customToast') as HTMLCToastsElement;
+    toast?.removeToast('custom');
+    this.hasCustomToast = false;
   }
   // @example-end
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@mdi/js": "^6.7.96",
     "@stencil/core": "^2.16.0",
     "@types/node": "^17.0.38",
-    "dompurify": "^2.3.10",
     "stencil-click-outside": "^1.8.0",
     "swiper": "^8.2.1",
     "uuid": "^8.3.2"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -107,7 +107,6 @@ export interface CToastMessage {
   indeterminate?: boolean;
   progress?: boolean;
   custom?: boolean;
-  template?: string;
 }
 
 export enum CAlertType {


### PR DESCRIPTION
This implementation suggests using `<slot />` logic instead of `innerHTML` when rendering custom toast-component content. 