### PR TITLE
Extend menu item with optional 'disabled' and 'icon' props

### DIFF
--- a/documentation/angular/src/app/examples/c-menu/c-menu.component.ts
+++ b/documentation/angular/src/app/examples/c-menu/c-menu.component.ts
@@ -9,10 +9,10 @@ import { mdiInformationOutline } from '@mdi/js';
 export class CMenuComponent {
   // @example-start|basic|nohover|small|simple
   items = [
-    { name: 'Item 1', action: () => alert('Item 1 selected')},
+    { name: 'Item 1', action: () => alert('Item 1 selected') },
     { name: 'Item 2', action: () => alert('Item 2 selected') },
     { name: 'Item 3', action: () => alert('Item 3 selected'), disabled: true },
-    { name: 'Item 4', action: () => alert('Item 4 selected'), icon: mdiInformationOutline},
+    { name: 'Item 4', action: () => alert('Item 4 selected'), icon: mdiInformationOutline, iconPosition: 'end' },
   ];
   // @example-end
 }

--- a/documentation/angular/src/app/examples/c-menu/c-menu.component.ts
+++ b/documentation/angular/src/app/examples/c-menu/c-menu.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { mdiInformationOutline } from '@mdi/js';
 
 @Component({
   selector: 'app-c-menu',
@@ -8,9 +9,10 @@ import { Component } from '@angular/core';
 export class CMenuComponent {
   // @example-start|basic|nohover|small|simple
   items = [
-    { name: 'Item 1', action: () => alert('Item 1 selected') },
+    { name: 'Item 1', action: () => alert('Item 1 selected')},
     { name: 'Item 2', action: () => alert('Item 2 selected') },
     { name: 'Item 3', action: () => alert('Item 3 selected'), disabled: true },
+    { name: 'Item 4', action: () => alert('Item 4 selected'), icon: mdiInformationOutline},
   ];
   // @example-end
 }

--- a/documentation/angular/src/app/examples/c-menu/c-menu.component.ts
+++ b/documentation/angular/src/app/examples/c-menu/c-menu.component.ts
@@ -10,6 +10,7 @@ export class CMenuComponent {
   items = [
     { name: 'Item 1', action: () => alert('Item 1 selected') },
     { name: 'Item 2', action: () => alert('Item 2 selected') },
+    { name: 'Item 3', action: () => alert('Item 3 selected'), disabled: true },
   ];
   // @example-end
 }

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -573,7 +573,7 @@ export namespace Components {
         /**
           * Menu items
          */
-        "items": { name: string; action: () => void }[];
+        "items": { name: string; action: () => void; disabled?: boolean }[];
         /**
           * No hover background
          */
@@ -2202,7 +2202,7 @@ declare namespace LocalJSX {
         /**
           * Menu items
          */
-        "items"?: { name: string; action: () => void }[];
+        "items"?: { name: string; action: () => void; disabled?: boolean }[];
         /**
           * No hover background
          */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -578,6 +578,7 @@ export namespace Components {
     action: () => void;
     disabled?: boolean;
     icon?: string;
+    iconPosition?: 'start' | 'end';
   }[];
         /**
           * No hover background
@@ -2212,6 +2213,7 @@ declare namespace LocalJSX {
     action: () => void;
     disabled?: boolean;
     icon?: string;
+    iconPosition?: 'start' | 'end';
   }[];
         /**
           * No hover background

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -573,7 +573,12 @@ export namespace Components {
         /**
           * Menu items
          */
-        "items": { name: string; action: () => void; disabled?: boolean }[];
+        "items": {
+    name: string;
+    action: () => void;
+    disabled?: boolean;
+    icon?: string;
+  }[];
         /**
           * No hover background
          */
@@ -2202,7 +2207,12 @@ declare namespace LocalJSX {
         /**
           * Menu items
          */
-        "items"?: { name: string; action: () => void; disabled?: boolean }[];
+        "items"?: {
+    name: string;
+    action: () => void;
+    disabled?: boolean;
+    icon?: string;
+  }[];
         /**
           * No hover background
          */

--- a/src/components/c-menu/c-menu.scss
+++ b/src/components/c-menu/c-menu.scss
@@ -1,7 +1,6 @@
 :host {
   border-radius: 4px;
   color: #595959;
-  cursor: pointer;
   display: block;
   font-size: 14px;
   position: relative;
@@ -84,10 +83,14 @@
       padding-right: 8px;
     }
 
-    &:hover,
+    &:not(.disabled):hover,
     &.active {
       background: #d8e8ea;
       color: var(--csc-primary);
+    }
+    &.disabled {
+      cursor: default;
+      opacity: .4;
     }
   }
 

--- a/src/components/c-menu/c-menu.scss
+++ b/src/components/c-menu/c-menu.scss
@@ -88,6 +88,13 @@
       background: #d8e8ea;
       color: var(--csc-primary);
     }
+    &.icon-start {
+      flex-direction: row-reverse;
+      justify-content: flex-end;
+    }
+    &.icon-end {
+      justify-content: space-between;
+    }
     &.disabled {
       cursor: default;
       opacity: .4;

--- a/src/components/c-menu/c-menu.tsx
+++ b/src/components/c-menu/c-menu.tsx
@@ -43,8 +43,12 @@ export class CMenu {
   /**
    * Menu items
    */
-  @Prop() items: { name: string; action: () => void; disabled?: boolean }[] =
-    [];
+  @Prop() items: {
+    name: string;
+    action: () => void;
+    disabled?: boolean;
+    icon?: string;
+  }[] = [];
 
   @Watch('currentIndex')
   onIndexChange(index: number) {
@@ -161,6 +165,12 @@ export class CMenu {
         onClick={() => onItemClick(item)}
       >
         {item.name}
+
+        {item.icon && (
+          <svg width="20" height="20" viewBox="0 0 24 24">
+            <path d={item.icon} />
+          </svg>
+        )}
       </li>
     );
   };

--- a/src/components/c-menu/c-menu.tsx
+++ b/src/components/c-menu/c-menu.tsx
@@ -43,7 +43,8 @@ export class CMenu {
   /**
    * Menu items
    */
-  @Prop() items: { name: string; action: () => void }[] = [];
+  @Prop() items: { name: string; action: () => void; disabled?: boolean }[] =
+    [];
 
   @Watch('currentIndex')
   onIndexChange(index: number) {
@@ -142,10 +143,23 @@ export class CMenu {
   private _getListItem = (item) => {
     const classes = {
       small: this.small,
+      disabled: item.disabled,
+    };
+
+    const onItemClick = (item) => {
+      if (!item.disabled) {
+        item.action();
+        this._hideMenu();
+      }
     };
 
     return (
-      <li class={classes} tabindex="-1" role="menuitem" onClick={item.action}>
+      <li
+        class={classes}
+        tabindex="-1"
+        role="menuitem"
+        onClick={() => onItemClick(item)}
+      >
         {item.name}
       </li>
     );
@@ -197,12 +211,7 @@ export class CMenu {
           )}
         </button>
 
-        <ul
-          id="c-menu-items"
-          class={menuClasses}
-          role="menu"
-          onClick={() => this._hideMenu()}
-        >
+        <ul id="c-menu-items" class={menuClasses} role="menu">
           {this.items.map((item) => this._getListItem(item))}
         </ul>
       </Host>

--- a/src/components/c-menu/c-menu.tsx
+++ b/src/components/c-menu/c-menu.tsx
@@ -106,8 +106,11 @@ export class CMenu {
     if (ev.key === 'Enter') {
       if (this.currentIndex !== null) {
         const selectedItem = this.items[this.currentIndex];
-        selectedItem.action();
-        this.menuVisible = false;
+
+        if (!selectedItem.disabled) {
+          selectedItem.action();
+          this.menuVisible = false;
+        }
 
         return;
       }

--- a/src/components/c-menu/c-menu.tsx
+++ b/src/components/c-menu/c-menu.tsx
@@ -48,6 +48,7 @@ export class CMenu {
     action: () => void;
     disabled?: boolean;
     icon?: string;
+    iconPosition?: 'start' | 'end';
   }[] = [];
 
   @Watch('currentIndex')
@@ -148,6 +149,8 @@ export class CMenu {
     const classes = {
       small: this.small,
       disabled: item.disabled,
+      'icon-start': item.iconPosition === 'start',
+      'icon-end': item.iconPosition === 'end',
     };
 
     const onItemClick = (item) => {
@@ -167,7 +170,7 @@ export class CMenu {
         {item.name}
 
         {item.icon && (
-          <svg width="20" height="20" viewBox="0 0 24 24">
+          <svg class="icon" width="20" height="20" viewBox="0 0 24 24">
             <path d={item.icon} />
           </svg>
         )}

--- a/src/components/c-menu/readme.md
+++ b/src/components/c-menu/readme.md
@@ -7,12 +7,12 @@
 
 ## Properties
 
-| Property  | Attribute | Description                                                                        | Type                                                                         | Default |
-| --------- | --------- | ---------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------- |
-| `items`   | --        | Menu items                                                                         | `{ name: string; action: () => void; disabled?: boolean; icon?: string; }[]` | `[]`    |
-| `nohover` | `nohover` | No hover background                                                                | `boolean`                                                                    | `false` |
-| `simple`  | `simple`  | Simple variant without chevron and background, E.g. when a button is the activator | `boolean`                                                                    | `false` |
-| `small`   | `small`   | Small variant                                                                      | `boolean`                                                                    | `false` |
+| Property  | Attribute | Description                                                                        | Type                                                                                                          | Default |
+| --------- | --------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------- |
+| `items`   | --        | Menu items                                                                         | `{ name: string; action: () => void; disabled?: boolean; icon?: string; iconPosition?: "start" \| "end"; }[]` | `[]`    |
+| `nohover` | `nohover` | No hover background                                                                | `boolean`                                                                                                     | `false` |
+| `simple`  | `simple`  | Simple variant without chevron and background, E.g. when a button is the activator | `boolean`                                                                                                     | `false` |
+| `small`   | `small`   | Small variant                                                                      | `boolean`                                                                                                     | `false` |
 
 
 ## Slots

--- a/src/components/c-menu/readme.md
+++ b/src/components/c-menu/readme.md
@@ -7,12 +7,12 @@
 
 ## Properties
 
-| Property  | Attribute | Description                                                                        | Type                                      | Default |
-| --------- | --------- | ---------------------------------------------------------------------------------- | ----------------------------------------- | ------- |
-| `items`   | --        | Menu items                                                                         | `{ name: string; action: () => void; }[]` | `[]`    |
-| `nohover` | `nohover` | No hover background                                                                | `boolean`                                 | `false` |
-| `simple`  | `simple`  | Simple variant without chevron and background, E.g. when a button is the activator | `boolean`                                 | `false` |
-| `small`   | `small`   | Small variant                                                                      | `boolean`                                 | `false` |
+| Property  | Attribute | Description                                                                        | Type                                                          | Default |
+| --------- | --------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------- | ------- |
+| `items`   | --        | Menu items                                                                         | `{ name: string; action: () => void; disabled?: boolean; }[]` | `[]`    |
+| `nohover` | `nohover` | No hover background                                                                | `boolean`                                                     | `false` |
+| `simple`  | `simple`  | Simple variant without chevron and background, E.g. when a button is the activator | `boolean`                                                     | `false` |
+| `small`   | `small`   | Small variant                                                                      | `boolean`                                                     | `false` |
 
 
 ## Slots

--- a/src/components/c-menu/readme.md
+++ b/src/components/c-menu/readme.md
@@ -7,12 +7,12 @@
 
 ## Properties
 
-| Property  | Attribute | Description                                                                        | Type                                                          | Default |
-| --------- | --------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------- | ------- |
-| `items`   | --        | Menu items                                                                         | `{ name: string; action: () => void; disabled?: boolean; }[]` | `[]`    |
-| `nohover` | `nohover` | No hover background                                                                | `boolean`                                                     | `false` |
-| `simple`  | `simple`  | Simple variant without chevron and background, E.g. when a button is the activator | `boolean`                                                     | `false` |
-| `small`   | `small`   | Small variant                                                                      | `boolean`                                                     | `false` |
+| Property  | Attribute | Description                                                                        | Type                                                                         | Default |
+| --------- | --------- | ---------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------- |
+| `items`   | --        | Menu items                                                                         | `{ name: string; action: () => void; disabled?: boolean; icon?: string; }[]` | `[]`    |
+| `nohover` | `nohover` | No hover background                                                                | `boolean`                                                                    | `false` |
+| `simple`  | `simple`  | Simple variant without chevron and background, E.g. when a button is the activator | `boolean`                                                                    | `false` |
+| `small`   | `small`   | Small variant                                                                      | `boolean`                                                                    | `false` |
 
 
 ## Slots


### PR DESCRIPTION
Implementation suggests adding an optional `disabled` prop for `c-menu` items.

Changes made:
- Optional `disabled` prop for menu item type
- Optional `icon` prop
- Optional `iconPosition` prop. Icon can be positioned in three different positions (start, after, end)
- Menu item click handler
- Disable menu hide on disabled item click (This is how MUI menu works)
- Updated documentation
- CSS styles for disabled menu items