### PR TITLE
Menu with custom trigger

### DIFF
--- a/documentation/angular/src/app/examples/c-menu/c-menu.component.html
+++ b/documentation/angular/src/app/examples/c-menu/c-menu.component.html
@@ -17,3 +17,13 @@
     </c-icon-button>
   </c-menu>
 </app-example>
+
+<app-example 
+  title="Programmatic variant (Angular)" 
+  subtitle="For use cases where menu needs to be customizable but it's not possible to directly append with child elements" 
+  name="custom" 
+  component="c-menu" 
+  cols
+>
+  <c-menu [items]="items" [customTrigger]="customTriggerProps"></c-menu>
+</app-example>

--- a/documentation/angular/src/app/examples/c-menu/c-menu.component.ts
+++ b/documentation/angular/src/app/examples/c-menu/c-menu.component.ts
@@ -1,5 +1,8 @@
 import { Component } from '@angular/core';
-import { mdiInformationOutline } from '@mdi/js';
+import { mdiDotsHorizontal, mdiInformationOutline } from '@mdi/js';
+import {
+  CMenuCustomTrigger
+} from '../../../../../../src/types';
 
 @Component({
   selector: 'app-c-menu',
@@ -7,12 +10,27 @@ import { mdiInformationOutline } from '@mdi/js';
   styleUrls: ['./c-menu.component.scss'],
 })
 export class CMenuComponent {
-  // @example-start|basic|nohover|small|simple
+  // @example-start|basic|nohover|small|simple|custom
   items = [
     { name: 'Item 1', action: () => alert('Item 1 selected') },
     { name: 'Item 2', action: () => alert('Item 2 selected') },
     { name: 'Item 3', action: () => alert('Item 3 selected'), disabled: true },
     { name: 'Item 4', action: () => alert('Item 4 selected'), icon: mdiInformationOutline, iconPosition: 'end' },
   ];
+  // @example-end
+
+  // @example-start|custom
+  customTriggerProps: CMenuCustomTrigger = {
+    value: 'Custom trigger',
+    component: {
+      tag: 'c-button',
+      params: {
+        text: true,
+        path: mdiDotsHorizontal,
+        title: 'Menu with custom trigger',
+        size: 'small',
+      },
+    },
+  }
   // @example-end
 }

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -5,7 +5,7 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { CAlertType, CAutocompleteItem, CDataTableData, CDataTableFooterOptions, CDataTableHeader, CPaginationOptions, CRadioGroupItem, CSelectItem, CToastMessage } from "./types";
+import { CAlertType, CAutocompleteItem, CDataTableData, CDataTableFooterOptions, CDataTableHeader, CMenuCustomTrigger, CPaginationOptions, CRadioGroupItem, CSelectItem, CToastMessage } from "./types";
 import { CardBackground } from "./components/c-card/c-card";
 import { CLoginCardBlendMode } from "./components/c-login-card/c-login-card";
 export namespace Components {
@@ -582,6 +582,10 @@ export namespace Components {
     interface CMain {
     }
     interface CMenu {
+        /**
+          * Programmatic trigger component
+         */
+        "customTrigger": CMenuCustomTrigger;
         /**
           * Menu items
          */
@@ -2225,6 +2229,10 @@ declare namespace LocalJSX {
     interface CMain {
     }
     interface CMenu {
+        /**
+          * Programmatic trigger component
+         */
+        "customTrigger"?: CMenuCustomTrigger;
         /**
           * Menu items
          */

--- a/src/components/c-menu/c-menu.scss
+++ b/src/components/c-menu/c-menu.scss
@@ -13,7 +13,7 @@
   }
 }
 
-:host(:focus-within) {
+:host(:focus-within):not(.custom-menu-trigger) {
   background: #d8e8ea;
   outline: 2px var(--csc-primary) solid;
   outline-offset: 2px;

--- a/src/components/c-menu/c-menu.tsx
+++ b/src/components/c-menu/c-menu.tsx
@@ -9,6 +9,7 @@ import {
   Watch,
 } from '@stencil/core';
 import { mdiChevronDown } from '@mdi/js';
+import { CMenuCustomTrigger } from '../../types';
 /**
  * @group Navigation
  * @slot - Menu title / activator element (simple variant)
@@ -39,6 +40,11 @@ export class CMenu {
    * No hover background
    */
   @Prop() nohover = false;
+
+  /**
+   * Programmatic trigger component
+   */
+  @Prop() customTrigger: CMenuCustomTrigger;
 
   /**
    * Menu items
@@ -148,6 +154,26 @@ export class CMenu {
     this.menuVisible = false;
   }
 
+  private _renderCustomTrigger() {
+    const props = this.customTrigger;
+
+    const Tag = props.component.tag;
+    const params = props.component.params;
+
+    return (
+      <Tag
+        {...params}
+        class="custom-menu-trigger"
+        aria-expanded={this.menuVisible.toString()}
+        aria-haspopup="true"
+        aria-controls="c-menu-items"
+        onClick={() => this._showMenu()}
+      >
+        {props.value}
+      </Tag>
+    );
+  }
+
   private _getListItem = (item) => {
     const classes = {
       small: this.small,
@@ -156,7 +182,9 @@ export class CMenu {
       'icon-end': item.iconPosition === 'end',
     };
 
-    const onItemClick = (item) => {
+    const onItemClick = (event, item) => {
+      event.stopPropagation();
+
       if (!item.disabled) {
         item.action();
         this._hideMenu();
@@ -168,7 +196,7 @@ export class CMenu {
         class={classes}
         tabindex="-1"
         role="menuitem"
-        onClick={() => onItemClick(item)}
+        onClick={(event) => onItemClick(event, item)}
       >
         {item.name}
 
@@ -197,35 +225,39 @@ export class CMenu {
 
     return (
       <Host class={hostClasses}>
-        <button
-          aria-expanded={this.menuVisible.toString()}
-          aria-haspopup="true"
-          aria-controls="c-menu-items"
-          class={{
-            'c-menu-wrapper': !this.simple,
-            simple: this.simple,
-          }}
-          type="button"
-          onClick={() => this._showMenu()}
-        >
-          {this.simple ? (
-            <slot></slot>
-          ) : (
-            <div class={this.small ? 'c-select-row small' : 'c-select-row'}>
+        {this.customTrigger ? (
+          this._renderCustomTrigger()
+        ) : (
+          <button
+            aria-expanded={this.menuVisible.toString()}
+            aria-haspopup="true"
+            aria-controls="c-menu-items"
+            class={{
+              'c-menu-wrapper': !this.simple,
+              simple: this.simple,
+            }}
+            type="button"
+            onClick={() => this._showMenu()}
+          >
+            {this.simple ? (
               <slot></slot>
-              <svg
-                width={this.small ? '16' : '22'}
-                height={this.small ? '16' : '22'}
-                viewBox="0 0 24 24"
-                class={
-                  this.menuVisible ? 'c-select-icon rotated' : 'c-select-icon'
-                }
-              >
-                <path d={mdiChevronDown} />
-              </svg>
-            </div>
-          )}
-        </button>
+            ) : (
+              <div class={this.small ? 'c-select-row small' : 'c-select-row'}>
+                <slot></slot>
+                <svg
+                  width={this.small ? '16' : '22'}
+                  height={this.small ? '16' : '22'}
+                  viewBox="0 0 24 24"
+                  class={
+                    this.menuVisible ? 'c-select-icon rotated' : 'c-select-icon'
+                  }
+                >
+                  <path d={mdiChevronDown} />
+                </svg>
+              </div>
+            )}
+          </button>
+        )}
 
         <ul id="c-menu-items" class={menuClasses} role="menu">
           {this.items.map((item) => this._getListItem(item))}

--- a/src/components/c-menu/readme.md
+++ b/src/components/c-menu/readme.md
@@ -7,12 +7,13 @@
 
 ## Properties
 
-| Property  | Attribute | Description                                                                        | Type                                                                                                          | Default |
-| --------- | --------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ------- |
-| `items`   | --        | Menu items                                                                         | `{ name: string; action: () => void; disabled?: boolean; icon?: string; iconPosition?: "start" \| "end"; }[]` | `[]`    |
-| `nohover` | `nohover` | No hover background                                                                | `boolean`                                                                                                     | `false` |
-| `simple`  | `simple`  | Simple variant without chevron and background, E.g. when a button is the activator | `boolean`                                                                                                     | `false` |
-| `small`   | `small`   | Small variant                                                                      | `boolean`                                                                                                     | `false` |
+| Property        | Attribute | Description                                                                        | Type                                                                                                          | Default     |
+| --------------- | --------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ----------- |
+| `customTrigger` | --        | Programmatic trigger component                                                     | `CMenuCustomTrigger`                                                                                          | `undefined` |
+| `items`         | --        | Menu items                                                                         | `{ name: string; action: () => void; disabled?: boolean; icon?: string; iconPosition?: "start" \| "end"; }[]` | `[]`        |
+| `nohover`       | `nohover` | No hover background                                                                | `boolean`                                                                                                     | `false`     |
+| `simple`        | `simple`  | Simple variant without chevron and background, E.g. when a button is the activator | `boolean`                                                                                                     | `false`     |
+| `small`         | `small`   | Small variant                                                                      | `boolean`                                                                                                     | `false`     |
 
 
 ## Slots

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -115,3 +115,13 @@ export enum CAlertType {
   Success = 'success',
   Info = 'info',
 }
+
+export interface CMenuCustomTrigger {
+  value: string;
+  component: {
+    tag: string;
+    params?: {
+      [key: string]: unknown;
+    };
+  };
+}


### PR DESCRIPTION
Implementation suggests an alternative way of rendering triggering component for c-menu.

One use case is in data-table where cell elements can't be appended with child components