### PR TITLE
Pagination translations

### DIFF
--- a/documentation/angular/src/app/examples/c-data-table/c-data-table.component.html
+++ b/documentation/angular/src/app/examples/c-data-table/c-data-table.component.html
@@ -41,9 +41,9 @@
   name="paginated"
   component="c-data-table"
 >
-  <c-row>
-    <c-menu class="mb-4" [items]="localeOptions">Change pagination language</c-menu>
-  </c-row>
+  <c-switch class="mb-4" (changeValue)="toggleTextOverride($event)" cControl>
+    Pagination text override
+  </c-switch>
 
   <c-data-table
     id="external-data"

--- a/documentation/angular/src/app/examples/c-data-table/c-data-table.component.html
+++ b/documentation/angular/src/app/examples/c-data-table/c-data-table.component.html
@@ -41,6 +41,10 @@
   name="paginated"
   component="c-data-table"
 >
+  <c-row>
+    <c-menu class="mb-4" [items]="localeOptions">Change pagination language</c-menu>
+  </c-row>
+
   <c-data-table
     id="external-data"
     [data]="pagedData"

--- a/documentation/angular/src/app/examples/c-data-table/c-data-table.component.ts
+++ b/documentation/angular/src/app/examples/c-data-table/c-data-table.component.ts
@@ -219,7 +219,6 @@ export class CDataTableComponent implements OnInit {
     currentPage: 1,
     startFrom: 0,
     endTo: 9,
-    locale: 'en',
   };
 
   externalSortBy = 'name';
@@ -228,19 +227,15 @@ export class CDataTableComponent implements OnInit {
 
   loading = false;
 
-  locales = [
-    {id: 'en', label: 'In English'},
-    {id: 'fi', label: 'Suomeksi'},
-    {id: 'sv', label: 'På svenska'},
-  ];
+  textOverride = false;
 
-  localeOptions = this.locales.map(locale => (
-    {
-      name: locale.label,
-      action: () => this.changeLocale(locale.id),
-    }
-  ));
-
+  textOverrides = {
+    itemsPerPageText: 'Kohteita sivulla:',
+    nextPage: 'Seuraava sivu',
+    prevPage: 'Edellinen sivu',
+    pageText: ({start, end, count}) => `${start} - ${end} / ${count}`,
+    pageOfText: ({pageNumber, count}) => `Sivu ${pageNumber} / ${count}`,
+  };
 
   constructor(private _ngZone: NgZone, private _http: HttpClient) {}
 
@@ -355,9 +350,13 @@ export class CDataTableComponent implements OnInit {
     this.loading = false;
   }
 
-  changeLocale = (locale) => {
+  toggleTextOverride(event) {
     this._ngZone.run(() => {
-      this.externalOptions = {...this.externalOptions, locale: locale}
+      this.externalOptions = {
+        ...this.externalOptions,
+        textOverrides: event.detail ? this.textOverrides : undefined
+      }
+
       this.getData();
     });
   }

--- a/documentation/angular/src/app/examples/c-data-table/c-data-table.component.ts
+++ b/documentation/angular/src/app/examples/c-data-table/c-data-table.component.ts
@@ -219,6 +219,7 @@ export class CDataTableComponent implements OnInit {
     currentPage: 1,
     startFrom: 0,
     endTo: 9,
+    locale: 'en',
   };
 
   externalSortBy = 'name';
@@ -226,6 +227,20 @@ export class CDataTableComponent implements OnInit {
   externalDirection = 'asc';
 
   loading = false;
+
+  locales = [
+    {id: 'en', label: 'In English'},
+    {id: 'fi', label: 'Suomeksi'},
+    {id: 'sv', label: 'På svenska'},
+  ];
+
+  localeOptions = this.locales.map(locale => (
+    {
+      name: locale.label,
+      action: () => this.changeLocale(locale.id),
+    }
+  ));
+
 
   constructor(private _ngZone: NgZone, private _http: HttpClient) {}
 
@@ -338,6 +353,13 @@ export class CDataTableComponent implements OnInit {
     });
 
     this.loading = false;
+  }
+
+  changeLocale = (locale) => {
+    this._ngZone.run(() => {
+      this.externalOptions = {...this.externalOptions, locale: locale}
+      this.getData();
+    });
   }
   // @example-end
 }

--- a/documentation/angular/src/app/examples/c-data-table/c-data-table.component.ts
+++ b/documentation/angular/src/app/examples/c-data-table/c-data-table.component.ts
@@ -230,7 +230,7 @@ export class CDataTableComponent implements OnInit {
   textOverride = false;
 
   textOverrides = {
-    itemsPerPageText: 'Kohteita sivulla:',
+    // itemsPerPageText: 'Kohteita sivulla:',
     nextPage: 'Seuraava sivu',
     prevPage: 'Edellinen sivu',
     pageText: ({start, end, count}) => `${start} - ${end} / ${count}`,

--- a/src/components/c-notification/readme.md
+++ b/src/components/c-notification/readme.md
@@ -9,7 +9,7 @@
 
 | Property       | Attribute  | Description                   | Type                                                                                                              | Default     |
 | -------------- | ---------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------- | ----------- |
-| `notification` | --         | notification contents         | `{ name: string; type: "warning" \| "error" \| "success" \| "info"; delay?: number; requiresClosing?: boolean; }` | `null`      |
+| `notification` | --         | notification contents         | `{ name: string; type: "info" \| "warning" \| "error" \| "success"; delay?: number; requiresClosing?: boolean; }` | `null`      |
 | `position`     | `position` | Position of the notifications | `"absolute" \| "fixed"`                                                                                           | `undefined` |
 
 

--- a/src/components/c-notification/readme.md
+++ b/src/components/c-notification/readme.md
@@ -9,7 +9,7 @@
 
 | Property       | Attribute  | Description                   | Type                                                                                                              | Default     |
 | -------------- | ---------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------- | ----------- |
-| `notification` | --         | notification contents         | `{ name: string; type: "info" \| "warning" \| "error" \| "success"; delay?: number; requiresClosing?: boolean; }` | `null`      |
+| `notification` | --         | notification contents         | `{ name: string; type: "error" \| "warning" \| "success" \| "info"; delay?: number; requiresClosing?: boolean; }` | `null`      |
 | `position`     | `position` | Position of the notifications | `"absolute" \| "fixed"`                                                                                           | `undefined` |
 
 

--- a/src/components/c-pagination/c-pagination.tsx
+++ b/src/components/c-pagination/c-pagination.tsx
@@ -93,6 +93,41 @@ export class CPagination {
     this._setRange();
   }
 
+  private _locale = 'en';
+
+  private _textContent = {
+    page: {
+      en: 'page',
+      fi: 'sivu',
+      sv: 'sida',
+    },
+    of: {
+      en: 'of',
+      fi: '/',
+      sv: 'av',
+    },
+    items: {
+      en: 'items',
+      fi: '',
+      sv: '',
+    },
+    previous: {
+      en: 'Previous',
+      fi: 'Edellinen',
+      sv: 'Föregående',
+    },
+    next: {
+      en: 'Next',
+      fi: 'Seuraava',
+      sv: 'Nästä',
+    },
+  };
+
+  // Translate text content
+  private _t(key: string) {
+    return this._textContent[key][this._locale];
+  }
+
   private _setRange() {
     this._currentPage = this.value.currentPage || 1;
     this._itemsPerPage = this.value.itemsPerPage || 25;
@@ -126,7 +161,9 @@ export class CPagination {
     return (
       <c-menu items={itemsPerPageOptions} nohover>
         <div>
-          <span class="items-per-page">{this._itemsPerPage} per page</span>
+          <span class="items-per-page">
+            {this._itemsPerPage} per {this._t('page')}
+          </span>
         </div>
       </c-menu>
     );
@@ -164,7 +201,9 @@ export class CPagination {
     );
     const start = this.value.startFrom + 1;
 
-    return `${start} - ${end} of ${this.value.itemCount} items`;
+    return `${start} - ${end} ${this._t('of')} ${
+      this.value.itemCount
+    } ${this._t('items')}`;
   }
 
   private _getArrowLeft(size) {
@@ -172,15 +211,15 @@ export class CPagination {
       <li>
         <c-icon-button
           aria-disabled={this.value.currentPage <= 1 ? 'true' : 'false'}
-          aria-label="previous page"
+          aria-label={`${this._t('previous')} ${this._t('page')} `}
           disabled={this.value.currentPage <= 1}
           size={size}
           text
           onClick={this._decreasePageNumber}
         >
           <span class="visuallyhidden">
-            Previous
-            <span>page</span>
+            {this._t('previous')}
+            <span>{this._t('page')}</span>
           </span>
           <svg width="24" height="24" viewBox="0 0 24 24">
             <path d={mdiChevronLeft} />
@@ -197,15 +236,15 @@ export class CPagination {
           aria-disabled={
             this.value.currentPage >= this._getTotalPages() ? 'true' : 'false'
           }
-          aria-label="next page"
+          aria-label={`${this._t('next')} ${this._t('page')} `}
           disabled={this.value.currentPage >= this._getTotalPages()}
           size={size}
           text
           onClick={this._increasePageNumber}
         >
           <span class="visuallyhidden">
-            Next
-            <span>page</span>
+            {this._t('next')}
+            <span>{this._t('page')}</span>
           </span>
           <svg width="24" height="24" viewBox="0 0 24 24">
             <path d={mdiChevronRight} />
@@ -229,9 +268,11 @@ export class CPagination {
     return (
       <li>
         <c-icon-button {...params}>
-          <span class="visuallyhidden">page </span>
+          <span class="visuallyhidden">{this._t('page')} </span>
           {number}
-          <span class="visuallyhidden">of {this._getTotalPages()}</span>
+          <span class="visuallyhidden">
+            {this._t('of')} {this._getTotalPages()}
+          </span>
         </c-icon-button>
       </li>
     );
@@ -282,6 +323,7 @@ export class CPagination {
   }
 
   private _getPageButtons(size) {
+    this._locale = this.value.locale || 'en'; // Default to English locale
     this._buttons = [];
     let buttonStart = 0;
     let buttonCount = this._getTotalPages() + 1;

--- a/src/components/c-pagination/c-pagination.tsx
+++ b/src/components/c-pagination/c-pagination.tsx
@@ -100,7 +100,7 @@ export class CPagination {
   };
 
   private _getText(key: string) {
-    const source = this.value.textOverrides
+    const source = this.value.textOverrides?.[key]
       ? this.value.textOverrides
       : this._textContent;
 
@@ -260,8 +260,6 @@ export class CPagination {
         count: this._getTotalPages(),
       });
     }
-
-    console.log(parsedPageOfTextOverride);
 
     return (
       <li>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,7 @@ export interface CPaginationOptions {
   itemsPerPage?: number;
   startFrom?: number;
   endTo?: number;
+  locale?: string;
 }
 
 export interface CSelectItem {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,15 @@ export interface CPaginationOptions {
   startFrom?: number;
   endTo?: number;
   locale?: string;
+  textOverrides?: CPaginationTextOverrides;
+}
+
+export interface CPaginationTextOverrides {
+  itemsPerPageText?: string;
+  nextPage?: string;
+  prevPage?: string;
+  pageText?: ({ start, end, count }) => string;
+  pageOfText?: ({ pageNumber, count }) => string;
 }
 
 export interface CSelectItem {


### PR DESCRIPTION
Implementation suggest that static strings in pagination component can be translated by locale.

Available locales are for English, Finnish and Swedish languages.

Closes #47 