### PR TITLE
Fix for clicking c-menu in table pagination

### DIFF
--- a/src/components/c-menu/c-menu.tsx
+++ b/src/components/c-menu/c-menu.tsx
@@ -229,7 +229,10 @@ export class CMenu {
               simple: this.simple,
             }}
             type="button"
-            onClick={() => this._showMenu()}
+            onClick={(event: Event) => {
+              event.stopPropagation();
+              this._showMenu();
+            }}
           >
             {this.simple ? (
               <slot></slot>


### PR DESCRIPTION
Fixing the bug that `registerClickOutside` prevented the footerOptions menu in c-data-table to open on click.

The reason is that the click event in footerOptions menu went up to the parent element which is c-data-table, thus `registerClickOutside` recognised the event target incorrectly and hided the menu items.

Fixes issue https://github.com/CSCfi/swift-browser-ui/issues/782
