### PR TITLE
Keyboard navigation fixes

### DIFF
--- a/src/components/c-data-table/c-data-table.tsx
+++ b/src/components/c-data-table/c-data-table.tsx
@@ -630,7 +630,7 @@ export class CDataTable {
   }
 
   private _onToggleAdditionalData(
-    event: MouseEvent,
+    event: KeyboardEvent | MouseEvent,
     value: string | number,
     row,
   ) {
@@ -672,6 +672,14 @@ export class CDataTable {
     }
 
     this._activeRows = [...this._activeRows, value];
+  }
+
+  private _handleKeyUp(event: KeyboardEvent, value: string | number, row) {
+    event.preventDefault();
+
+    if (event.key === 'Enter') {
+      this._onToggleAdditionalData(event, value, row);
+    }
   }
 
   private _refresh() {
@@ -777,11 +785,16 @@ export class CDataTable {
     });
   }
 
-  private _renderExpansionIndicator() {
+  private _renderExpansionIndicator(rowIndex: number, rowData = {}) {
     return (
       this._hasHiddenData && (
         <td>
-          <div>
+          <div
+            tabindex="0"
+            onKeyUp={(event: KeyboardEvent) =>
+              this._handleKeyUp(event, rowIndex, rowData)
+            }
+          >
             <svg width="22" height="22" viewBox="0 0 24 24">
               <path d={mdiChevronDown} />
             </svg>
@@ -876,7 +889,7 @@ export class CDataTable {
               }
             >
               {this._renderSelectionCell(isSelected, selectionValue)}
-              {this._renderExpansionIndicator()}
+              {this._renderExpansionIndicator(rowIndex, rowData)}
               {this._renderTableCells(rowIndex, rowData)}
             </tr>
 

--- a/src/components/c-menu/c-menu.scss
+++ b/src/components/c-menu/c-menu.scss
@@ -136,7 +136,6 @@
     position: relative;
     padding-left: 14px;
     z-index: 2;
-    outline: none;
   }
 
   .c-menu-wrapper:hover {

--- a/src/components/c-menu/c-menu.tsx
+++ b/src/components/c-menu/c-menu.tsx
@@ -241,10 +241,7 @@ export class CMenu {
                 simple: this.simple,
               }}
               type="button"
-              onClick={(event: Event) => {
-                event.stopPropagation();
-                this._showMenu();
-              }}
+              onClick={() => this._showMenu()}
             >
               {this.simple ? (
                 <slot></slot>

--- a/src/components/c-navigationbutton/c-navigationbutton.tsx
+++ b/src/components/c-navigationbutton/c-navigationbutton.tsx
@@ -52,6 +52,6 @@ export class CNavigationbutton {
   );
 
   render() {
-    return <Host>{this._svg}</Host>;
+    return <Host tabindex={0}>{this._svg}</Host>;
   }
 }

--- a/src/components/c-pagination/c-pagination.tsx
+++ b/src/components/c-pagination/c-pagination.tsx
@@ -137,8 +137,12 @@ export class CPagination {
       }),
     );
 
+    const onMenuClick = (event) => {
+      event.stopPropagation();
+    };
+
     return (
-      <c-menu items={itemsPerPageOptions} nohover>
+      <c-menu items={itemsPerPageOptions} nohover onClick={onMenuClick}>
         <div>
           <span class="items-per-page">
             {this._getText('itemsPerPageText')} {this._itemsPerPage}

--- a/src/components/c-sidenavigation/c-sidenavigation.tsx
+++ b/src/components/c-sidenavigation/c-sidenavigation.tsx
@@ -41,13 +41,19 @@ export class CSidenavigation {
   }
 
   componentDidLoad() {
-    document
-      .querySelector('body')
-      .addEventListener('click', (event: MouseEvent) => {
-        if ((event.target as HTMLElement).matches('c-navigationbutton')) {
-          this.menuVisible = !this.menuVisible;
+    const el = document.querySelector('body');
+
+    ['click', 'keyup'].forEach((eventType) => {
+      el.addEventListener(eventType, (e: MouseEvent | KeyboardEvent) => {
+        if ((e.target as HTMLElement).matches('c-navigationbutton')) {
+          if (eventType === 'click') {
+            this.menuVisible = !this.menuVisible;
+          } else if (e instanceof KeyboardEvent && e.key === 'Enter') {
+            this.menuVisible = !this.menuVisible;
+          }
         }
       });
+    });
   }
 
   private _closeMenu() {


### PR DESCRIPTION
#### Changes I made: 
- `outline: none` was removed for `c-menu` so it can get back the browser's default focus style. Users can know that the menu is focused when navigating with keyboard. Related info could be found here: https://developer.mozilla.org/en-US/docs/Web/CSS/outline#accessibility_concerns
- **Expansion Indicator** in `c-data-table` with hidden content could be focused and opened (by `<enter>`) when using keyboard to navigate.
- Make navigation burger icon (in mobile view) focusable and openable when using keyboard
- Fix for `c-menu` to be opened correctly when it is nested inside `c-data-table` 