### PR TITLE
Add possibility to render external custom menu

### DIFF
--- a/documentation/angular/package-lock.json
+++ b/documentation/angular/package-lock.json
@@ -13903,13 +13903,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@csstools/postcss-unset-value/-/postcss-unset-value-1.0.1.tgz",
       "integrity": "sha512-f1G1WGDXEU/RN1TWAxBPQgQudtLnLQPyiWdtypkPC+mVYNKFKH/HYXSxH4MVNqwF8M0eDsoiU7HumJHCg/L/jg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@csstools/selector-specificity": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.0.1.tgz",
       "integrity": "sha512-aG20vknL4/YjQF9BSV7ts4EWm/yrjagAN7OWBNmlbEOUiu0llj4OGrFoOKK3g2vey4/p2omKCoHrWtPxSwV3HA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@discoveryjs/json-ext": {
       "version": "0.5.7",
@@ -13990,7 +13992,8 @@
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-14.0.1.tgz",
       "integrity": "sha512-BR+RoOK8/20mRx86D6cYGjc0+/qsGvIpLHknRd9WfxB7ppfbWV8QTN9vnk3lRs13n2umRJ+8VvC8UMmd8B+m9A==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -14532,7 +14535,8 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
       "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "adjust-sourcemap-loader": {
       "version": "4.0.0",
@@ -14632,7 +14636,8 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-colors": {
       "version": "4.1.1",
@@ -14942,7 +14947,8 @@
     "bootstrap": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
-      "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q=="
+      "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
+      "requires": {}
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -15678,7 +15684,8 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-6.0.3.tgz",
       "integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "css-select": {
       "version": "4.2.1",
@@ -16985,7 +16992,8 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ieee754": {
       "version": "1.2.1",
@@ -17631,7 +17639,8 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/karma-jasmine-html-reporter/-/karma-jasmine-html-reporter-1.7.0.tgz",
       "integrity": "sha512-pzum1TL7j90DTE86eFt48/s12hqwQuiD+e5aXx2Dc9wDEn2LfGq6RoAxEZZjFiN0RDSCOnosEKRZWxbQ+iMpQQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "karma-source-map-support": {
       "version": "1.4.0",
@@ -19176,13 +19185,15 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-5.0.0.tgz",
       "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-gap-properties": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-3.0.3.tgz",
       "integrity": "sha512-rPPZRLPmEKgLk/KlXMqRaNkYTUpE7YC+bOIQFN5xcu1Vp11Y4faIXv6/Jpft6FMnl6YRxZqDZG0qQOW80stzxQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-image-set-function": {
       "version": "4.0.6",
@@ -19208,7 +19219,8 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-4.0.1.tgz",
       "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-lab-function": {
       "version": "4.2.0",
@@ -19235,19 +19247,22 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-5.0.4.tgz",
       "integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-media-minmax": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-5.0.0.tgz",
       "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
       "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -19298,13 +19313,15 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-3.0.3.tgz",
       "integrity": "sha512-CxZwoWup9KXzQeeIxtgOciQ00tDtnylYIlJBBODqkgS/PU2jISuWOL/mYLHmZb9ZhZiCaNKsCRiLp22dZUtNsg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-page-break": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-3.0.4.tgz",
       "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-place": {
       "version": "7.0.4",
@@ -19381,7 +19398,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-4.0.0.tgz",
       "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-selector-not": {
       "version": "5.0.0",
@@ -20946,7 +20964,8 @@
           "version": "8.8.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
           "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -21074,7 +21093,8 @@
       "version": "8.2.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
       "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "y18n": {
       "version": "5.0.8",

--- a/documentation/angular/src/app/examples/c-autocomplete/c-autocomplete.component.html
+++ b/documentation/angular/src/app/examples/c-autocomplete/c-autocomplete.component.html
@@ -57,3 +57,33 @@
     <li *ngIf="!tags.length">No added values</li>
   </ul>
 </app-example>
+
+<app-example title="Usage with custom menu items" name="customMenu" component="c-autocomplete">
+  <c-row gap="8">
+    <c-autocomplete
+      id="customListOfCountries"
+      label="Countries"
+      cControl
+      hide-details
+      [items]="filteredItems"
+      [query]="query"
+      (changeQuery)="changeQuery($event)"
+      [itemsPerPage]="3"
+      [(ngModel)]="selection"
+      style="flex: 1"
+      [customMenu]="true"
+    >
+      <i class="mdi mdi-earth" slot="pre"></i>
+      <div
+        *ngFor="let item of filteredItems; let i = index"
+        slot="customMenu"
+        (click)="setValue($event, item)"
+      >
+        <span>
+          <b>Country {{ i + 1 }}</b>
+        </span>
+        <p>{{ item.name }}</p>
+      </div>
+    </c-autocomplete>
+  </c-row>
+</app-example>

--- a/documentation/angular/src/app/examples/c-autocomplete/c-autocomplete.component.scss
+++ b/documentation/angular/src/app/examples/c-autocomplete/c-autocomplete.component.scss
@@ -1,0 +1,11 @@
+div[slot='customMenu'] {
+  padding: 5px 10px;
+  p {
+    margin: 0;
+  }
+}
+
+div[aria-selected='true'],
+div[slot='customMenu']:hover {
+  background-color: var(--csc-primary-text-hover);
+}

--- a/documentation/angular/src/app/examples/c-autocomplete/c-autocomplete.component.ts
+++ b/documentation/angular/src/app/examples/c-autocomplete/c-autocomplete.component.ts
@@ -43,6 +43,16 @@ export class CAutocompleteComponent implements OnInit {
   }
   // @example-end
 
+  // @example-start|customMenu
+  setValue(event: Event, item: CAutocompleteItem) {
+    const autocomplete = document.querySelector(
+      '#customListOfCountries',
+    ) as HTMLCAutocompleteElement;
+
+    autocomplete.setValue(event, item);
+  }
+  // @example-end
+
   // @example-start|returnValue
   searchString: any;
 

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -83,6 +83,10 @@ export namespace Components {
          */
         "autofocus": boolean;
         /**
+          * Render custom menu
+         */
+        "customMenu": boolean;
+        /**
           * Dense variant
          */
         "dense": boolean;
@@ -2220,6 +2224,10 @@ declare namespace LocalJSX {
           * Auto focus the input
          */
         "autofocus"?: boolean;
+        /**
+          * Render custom menu
+         */
+        "customMenu"?: boolean;
         /**
           * Dense variant
          */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -139,6 +139,10 @@ export namespace Components {
          */
         "returnValue": false;
         /**
+          * Sets the value of the autocomplete externally
+         */
+        "setValue": (event: any, item: any) => Promise<void>;
+        /**
           * Shadow variant
          */
         "shadow": boolean;

--- a/src/components/c-autocomplete/c-autocomplete.tsx
+++ b/src/components/c-autocomplete/c-autocomplete.tsx
@@ -9,6 +9,7 @@ import {
   Event,
   EventEmitter,
   Watch,
+  Method,
 } from '@stencil/core';
 import { mdiChevronDown, mdiAlert } from '@mdi/js';
 import { v4 as uuid } from 'uuid';
@@ -138,6 +139,14 @@ export class CAutocomplete {
    * Triggered when an item is selected
    */
   @Event({ bubbles: false }) changeValue: EventEmitter;
+
+  /**
+   * Sets the value of the autocomplete externally
+   */
+  @Method()
+  async setValue(event, item) {
+    this._select(event, item);
+  }
 
   private _valueChangedHandler(item: string | number | CAutocompleteItem) {
     function isItem(element) {
@@ -425,6 +434,18 @@ export class CAutocomplete {
 
   private _renderCustomMenu(style) {
     if (this.currentIndex === 0 && this.menuVisible) {
+      const selectedItem = document.querySelectorAll(
+        'div[aria-selected = "true"]',
+      );
+
+      if (selectedItem.length === 1) {
+        /**
+          When currentIndex is 0 and there is no query text,
+          remove aria-selected attribute from current highlighted item
+         */
+        selectedItem[0].toggleAttribute('aria-selected');
+      }
+
       const currentItem = this._getItemRef(this.currentIndex);
       currentItem.setAttribute('aria-selected', 'true');
     }

--- a/src/components/c-autocomplete/c-autocomplete.tsx
+++ b/src/components/c-autocomplete/c-autocomplete.tsx
@@ -29,6 +29,12 @@ export class CAutocomplete {
   @Prop() autofocus = false;
 
   /**
+    Render custom menu
+  */
+
+  @Prop() customMenu = false;
+
+  /**
    * Disable the input
    */
   @Prop() disabled = false;
@@ -213,6 +219,13 @@ export class CAutocomplete {
         this.currentIndex += 1;
       }
 
+      if (this.customMenu && this.currentIndex > 0) {
+        const currentItem = this._getItemRef(this.currentIndex);
+        const prevItem = this._getItemRef(this.currentIndex - 1);
+        prevItem.toggleAttribute('aria-selected');
+        currentItem.setAttribute('aria-selected', 'true');
+      }
+
       this._scrollToElement();
     }
 
@@ -230,6 +243,13 @@ export class CAutocomplete {
         this.currentIndex -= 1;
       } else if (this.currentIndex === null) {
         this.currentIndex = this.items.length - 1;
+      }
+
+      if (this.customMenu && this.currentIndex >= 0) {
+        const currentItem = this._getItemRef(this.currentIndex);
+        const prevItem = this._getItemRef(this.currentIndex + 1);
+        prevItem.toggleAttribute('aria-selected');
+        currentItem.setAttribute('aria-selected', 'true');
       }
 
       this._scrollToElement();
@@ -251,6 +271,14 @@ export class CAutocomplete {
     }
   }
 
+  private _getItemRef(index) {
+    const itemRef = this._itemRefs.find(
+      (item) => item.value === this.items[index].value,
+    )?.ref;
+
+    return itemRef;
+  }
+
   private _observer = new IntersectionObserver(
     (entries, observer) => {
       entries.forEach((entry) => {
@@ -270,9 +298,7 @@ export class CAutocomplete {
 
   private _scrollToElement() {
     if (this.items.length > this.itemsPerPage) {
-      const itemRef = this._itemRefs.find(
-        (item) => item.value === this.items[this.currentIndex].value,
-      )?.ref;
+      const itemRef = this._getItemRef(this.currentIndex);
 
       if (!!itemRef) {
         this._observer.observe(itemRef);
@@ -384,6 +410,53 @@ export class CAutocomplete {
     );
   }
 
+  private _renderEmptyMenu() {
+    return (
+      <ul class="c-input-menu__items c-input-menu__items--empty">
+        <li tabindex="-1">
+          <svg viewBox="0 0 24 24">
+            <path d={mdiAlert} />
+          </svg>
+          No suggestions found
+        </li>
+      </ul>
+    );
+  }
+
+  private _renderCustomMenu(style) {
+    if (this.currentIndex === 0 && this.menuVisible) {
+      const currentItem = this._getItemRef(this.currentIndex);
+      currentItem.setAttribute('aria-selected', 'true');
+    }
+
+    return (
+      <div
+        class={{
+          'c-input-menu__item-wrapper': true,
+          'c-input-menu__item-wrapper--shadow': this.shadow,
+        }}
+      >
+        {!!this.items.length && this.menuVisible && (
+          <div
+            id={'results_' + this._id}
+            class={
+              this.menuVisible
+                ? 'c-input-menu__items'
+                : 'c-input-menu__items c-input-menu__items--hidden'
+            }
+            style={style}
+          >
+            <slot name="customMenu" />
+          </div>
+        )}
+        {!this.items.length &&
+          this.menuVisible &&
+          this.query.length > 0 &&
+          this._renderEmptyMenu()}
+      </div>
+    );
+  }
+
   private _renderMenu(style) {
     return (
       <div
@@ -426,17 +499,7 @@ export class CAutocomplete {
               ))}
           </ul>
         )}
-
-        {!this.items.length && this.menuVisible && (
-          <ul class="c-input-menu__items c-input-menu__items--empty">
-            <li tabindex="-1">
-              <svg viewBox="0 0 24 24">
-                <path d={mdiAlert} />
-              </svg>
-              No suggestions found
-            </li>
-          </ul>
-        )}
+        {!this.items.length && this.menuVisible && this._renderEmptyMenu()}
       </div>
     );
   }
@@ -476,6 +539,17 @@ export class CAutocomplete {
       };
     }
 
+    if (this.customMenu) {
+      const slotContent = document.querySelectorAll('[slot="customMenu"]');
+
+      for (let i = 0; i < this.items.length; i++) {
+        this._itemRefs.push({
+          value: this.items[i].value,
+          ref: slotContent[i] as HTMLElement,
+        });
+      }
+    }
+
     return (
       <Host>
         <div
@@ -509,7 +583,9 @@ export class CAutocomplete {
 
           <div class="c-input__content">
             {this._renderInputElement()}
-            {this._renderMenu(itemsPerPageStyle)}
+            {this.customMenu
+              ? this._renderCustomMenu(itemsPerPageStyle)
+              : this._renderMenu(itemsPerPageStyle)}
             {this._renderChevron()}
           </div>
 

--- a/src/components/c-autocomplete/readme.md
+++ b/src/components/c-autocomplete/readme.md
@@ -40,6 +40,19 @@
 | `changeValue` | Triggered when an item is selected | `CustomEvent<any>` |
 
 
+## Methods
+
+### `setValue(event: any, item: any) => Promise<void>`
+
+Sets the value of the autocomplete externally
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+
 ## Dependencies
 
 ### Depends on

--- a/src/components/c-autocomplete/readme.md
+++ b/src/components/c-autocomplete/readme.md
@@ -10,6 +10,7 @@
 | Property         | Attribute          | Description                                                  | Type                                    | Default            |
 | ---------------- | ------------------ | ------------------------------------------------------------ | --------------------------------------- | ------------------ |
 | `autofocus`      | `autofocus`        | Auto focus the input                                         | `boolean`                               | `false`            |
+| `customMenu`     | `custom-menu`      | Render custom menu                                           | `boolean`                               | `false`            |
 | `dense`          | `dense`            | Dense variant                                                | `boolean`                               | `undefined`        |
 | `disabled`       | `disabled`         | Disable the input                                            | `boolean`                               | `false`            |
 | `hideDetails`    | `hide-details`     | Hide the hint and error messages                             | `boolean`                               | `false`            |

--- a/src/components/c-notification/readme.md
+++ b/src/components/c-notification/readme.md
@@ -9,7 +9,7 @@
 
 | Property       | Attribute  | Description                   | Type                                                                                                              | Default     |
 | -------------- | ---------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------- | ----------- |
-| `notification` | --         | notification contents         | `{ name: string; type: "info" \| "error" \| "success" \| "warning"; delay?: number; requiresClosing?: boolean; }` | `null`      |
+| `notification` | --         | notification contents         | `{ name: string; type: "error" \| "warning" \| "success" \| "info"; delay?: number; requiresClosing?: boolean; }` | `null`      |
 | `position`     | `position` | Position of the notifications | `"absolute" \| "fixed"`                                                                                           | `undefined` |
 
 

--- a/vscode-data.json
+++ b/vscode-data.json
@@ -98,6 +98,10 @@
           "description": "Auto focus the input"
         },
         {
+          "name": "custom-menu",
+          "description": "Render custom menu"
+        },
+        {
           "name": "dense",
           "description": "Dense variant"
         },


### PR DESCRIPTION
Current `c-autocomplete` component renders the menu as a list of item's `name`.

This PR added another possibility to render custom menu item as the example shown in the below image from [Buefy](https://buefy.org/documentation/autocomplete#async-with-custom-template)

Changes I made: 
- a `<slot />`  to render external menu items when `customMenu` is `true`
- Custom menu items are added to `_itemRefs` array to make it consistent when handling `keydown` event
- `aria-selected` attribute is then toggled `true/false` to highlight item depending on pressing `ArrowDown/ArrowUp` keys
- `_getItemRef` is reusable to get a specific itemRef in `_itemRefs` array   
  
<br />


![Screenshot 2023-03-09 at 16 18 20](https://user-images.githubusercontent.com/23532204/224052601-e7a3de21-0152-465c-8ad3-76f648f95515.png)
