### PR TITLE
Fix for listening to placeholder's change

### DIFF
--- a/src/components/c-input/c-input.tsx
+++ b/src/components/c-input/c-input.tsx
@@ -215,6 +215,11 @@ export class CInput {
     if (!value) this._onReset();
   }
 
+  @Watch('placeholder')
+  onPlaceholderChange(placeholder) {
+    if (placeholder) this._onReset();
+  }
+
   private _hasBlurred = false;
 
   private _labelRef: HTMLLabelElement;


### PR DESCRIPTION
Added the listener for placeholder's change in `c-input`. 

This should fix, for example, when changing between different languages, the placeholder text will change accordingly.